### PR TITLE
공통 응답, 예외 처리 및 전역 설정

### DIFF
--- a/src/main/java/com/goormthon/univ/simhae/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.goormthon.univ.simhae.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/goormthon/univ/simhae/global/domain/BaseEntity.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/domain/BaseEntity.java
@@ -1,0 +1,19 @@
+package com.goormthon.univ.simhae.global.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/global/dto/ErrorResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/dto/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.goormthon.univ.simhae.global.dto;
+
+import com.goormthon.univ.simhae.global.exception.message.ErrorMessage;
+
+public record ErrorResponse(
+        int status,
+        String message
+) {
+    public static ErrorResponse of(final ErrorMessage errorMessage) {
+        return new ErrorResponse(
+                errorMessage.getStatus(),
+                errorMessage.getMessage()
+        );
+    }
+
+    public static ErrorResponse of(final int status, final String message) {
+        return new ErrorResponse(status, message);
+    }
+}

--- a/src/main/java/com/goormthon/univ/simhae/global/dto/SuccessResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/dto/SuccessResponse.java
@@ -1,0 +1,17 @@
+package com.goormthon.univ.simhae.global.dto;
+
+import com.goormthon.univ.simhae.global.exception.message.SuccessMessage;
+
+public record SuccessResponse<T>(
+        int status,
+        String message,
+        T data
+) {
+    public static <T> SuccessResponse of(final SuccessMessage successMessage, final T data) {
+        return new SuccessResponse(successMessage.getStatus(), successMessage.getMessage(), data);
+    }
+
+    public static SuccessResponse of(final SuccessMessage successMessage) {
+        return new SuccessResponse(successMessage.getStatus(), successMessage.getMessage(), null);
+    }
+}

--- a/src/main/java/com/goormthon/univ/simhae/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,68 @@
+package com.goormthon.univ.simhae.global.exception;
+
+import com.goormthon.univ.simhae.global.dto.ErrorResponse;
+import com.goormthon.univ.simhae.global.exception.message.ErrorMessage;
+import com.goormthon.univ.simhae.global.exception.model.BadRequestException;
+import com.goormthon.univ.simhae.global.exception.model.SimhaeException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequestException(final BadRequestException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(e.getErrorMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        FieldError fieldError = e.getBindingResult().getFieldError();
+
+        // 기본 메시지
+        ErrorMessage errorMessage = ErrorMessage.REQUIRED_FIELD_MISSING;
+
+        if (fieldError != null) {
+            String code = fieldError.getCode();
+            Object rejectedValue = fieldError.getRejectedValue();
+            int length = rejectedValue != null ? rejectedValue.toString().length() : 0;
+
+            switch (code) {
+                case "NotNull", "NotBlank" -> errorMessage = ErrorMessage.REQUIRED_FIELD_MISSING;
+                case "Size" -> {
+                    int min = (int) fieldError.getArguments()[1];
+                    int max = (int) fieldError.getArguments()[2];
+
+                    if (length < min) {
+                        errorMessage = ErrorMessage.INPUT_VALUE_TOO_SHORT; // 최소 길이 미만
+                    } else if (length > max) {
+                        errorMessage = ErrorMessage.INPUT_VALUE_TOO_LONG;  // 최대 길이 초과
+                    }
+                }
+            }
+        }
+
+        return ResponseEntity.badRequest().body(ErrorResponse.of(errorMessage));
+    }
+
+    @ExceptionHandler(SimhaeException.class)
+    public ResponseEntity<ErrorResponse> handleSimhaeException(final SimhaeException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(e.getErrorMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(final Exception e) {
+        // 로그 찍기 등 필요 시
+        e.printStackTrace();
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(ErrorMessage.INTERNAL_SERVER_ERROR));
+    }
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/global/exception/message/ErrorMessage.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/exception/message/ErrorMessage.java
@@ -1,0 +1,24 @@
+package com.goormthon.univ.simhae.global.exception.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+    // 400 Bad Request
+    REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST.value(), "필수 입력값이 누락되었습니다"),
+    INPUT_VALUE_TOO_SHORT(HttpStatus.BAD_REQUEST.value(), "입력값이 최소 길이보다 짧습니다"),
+    INPUT_VALUE_TOO_LONG(HttpStatus.BAD_REQUEST.value(), "입력값이 최대 길이를 초과했습니다"),
+
+    // 404 Not Found
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 데이터를 찾을 수 없습니다"),
+
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다"),
+    ;
+
+    private final int status;    // HTTP 상태 코드
+    private final String message; // 에러 메시지
+}

--- a/src/main/java/com/goormthon/univ/simhae/global/exception/message/SuccessMessage.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/exception/message/SuccessMessage.java
@@ -1,0 +1,28 @@
+package com.goormthon.univ.simhae.global.exception.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage {
+    /*
+    200 OK
+     */
+    LOAD_SUCCESS(HttpStatus.OK.value(),"꿈 조회가 완료되었습니다"),
+
+    /*
+    201 Created
+     */
+    CREATE_SUCCESS(HttpStatus.CREATED.value(), "꿈 해몽 생성이 완료되었습니다"),
+
+    /*
+    204 No Content
+     */
+    DELETED_SUCCESS(HttpStatus.NO_CONTENT.value(), "삭제가 완료되었습니다");
+    ;
+
+    private final int status;    // HTTP 상태 코드
+    private final String message; // 성공 메시지
+}

--- a/src/main/java/com/goormthon/univ/simhae/global/exception/model/BadRequestException.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/exception/model/BadRequestException.java
@@ -1,0 +1,12 @@
+package com.goormthon.univ.simhae.global.exception.model;
+
+
+import com.goormthon.univ.simhae.global.exception.message.ErrorMessage;
+
+public class BadRequestException extends SimhaeException {
+
+    public BadRequestException(final ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/global/exception/model/SimhaeException.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/exception/model/SimhaeException.java
@@ -1,0 +1,16 @@
+package com.goormthon.univ.simhae.global.exception.model;
+
+import com.goormthon.univ.simhae.global.exception.message.ErrorMessage;
+import lombok.Getter;
+
+@Getter
+public class SimhaeException extends RuntimeException {
+
+    private final ErrorMessage errorMessage;
+
+    public SimhaeException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage());
+        this.errorMessage = errorMessage;
+    }
+
+}


### PR DESCRIPTION
## Related Issues
- #1 

## 작업 내용
- JPA Auditing 설정 및 BaseEntity 구현
- 공통 응답 DTO(SuccessResponse, ErrorResponse) 구현
- 공통 예외 처리 구조(GlobalExceptionHandler) 및 ErrorMessage/SuccessMessage enum 정의
- 커스텀 예외(BadRequestException, SimhaeException) 구현
## 참고 사항
GlobalExceptionHandler에서 BadRequest, Validation, SimhaeException, 기타 Exception 처리

## ScreenShot
<img width="329" height="526" alt="스크린샷 2025-08-29 오후 11 35 10" src="https://github.com/user-attachments/assets/ab71c19d-5ee4-4a49-829a-528d05648e98" />
