### PR TITLE
꿈 해몽 기능 구현 및 AI 분석 연동

### DIFF
--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/repository/DreamRepository.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/repository/DreamRepository.java
@@ -1,0 +1,12 @@
+package com.goormthon.univ.simhae.domain.dream.repository;
+
+import com.goormthon.univ.simhae.domain.dream.entity.Dream;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DreamRepository extends JpaRepository<Dream, Long> {
+
+    List<Dream> findTop7ByUserIdOrderByCreatedAtDesc(Long userId);
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/controller/DreamAnalysisController.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/controller/DreamAnalysisController.java
@@ -1,0 +1,42 @@
+package com.goormthon.univ.simhae.domain.fastapi.controller;
+
+import com.goormthon.univ.simhae.domain.fastapi.dto.overall.DreamAnalyzeRequest;
+import com.goormthon.univ.simhae.domain.fastapi.dto.unconscious.UnconsciousAnalysisResponse;
+import com.goormthon.univ.simhae.domain.fastapi.service.DreamAnalysisService;
+import com.goormthon.univ.simhae.global.dto.SuccessResponse;
+import com.goormthon.univ.simhae.global.exception.message.SuccessMessage;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/ai/dreams")
+@RequiredArgsConstructor
+public class DreamAnalysisController {
+
+    private final DreamAnalysisService dreamAnalysisService;
+
+    // AI 꿈 해몽 - 재진술, 무의식, 제안
+    @PostMapping("/overall")
+    public ResponseEntity<SuccessResponse<Map<String, Object>>> analyzeOverall(
+            @RequestBody @Valid DreamAnalyzeRequest request) {
+
+        Map<String, Object> result = dreamAnalysisService.analyzeOverall(request);
+        return ResponseEntity.status(201)
+                .body(SuccessResponse.of(SuccessMessage.CREATE_SUCCESS, result));
+    }
+
+    // 무의식 분석 - 최근 7개 꿈
+    @PostMapping("/unconscious")
+    public ResponseEntity<SuccessResponse<UnconsciousAnalysisResponse>> analyzeUnconscious(
+            @RequestParam Long userId) {
+
+        UnconsciousAnalysisResponse result = dreamAnalysisService.analyzeUnconscious(userId);
+        return ResponseEntity.status(201)
+                .body(SuccessResponse.of(SuccessMessage.UNCONSCIOUS_SUCCESS, result));
+    }
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/DreamAnalyzeRequest.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/DreamAnalyzeRequest.java
@@ -1,0 +1,19 @@
+package com.goormthon.univ.simhae.domain.fastapi.dto.overall;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class DreamAnalyzeRequest {
+
+    @NotNull
+    private String content;       // 꿈 원문
+    private LocalDate dreamDate;  // 꿈 날짜
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/RecommendationResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/RecommendationResponse.java
@@ -1,0 +1,14 @@
+package com.goormthon.univ.simhae.domain.fastapi.dto.overall;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RecommendationResponse {
+
+    private String suggestion; // AI 제안
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/RephraseResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/RephraseResponse.java
@@ -1,0 +1,16 @@
+package com.goormthon.univ.simhae.domain.fastapi.dto.overall;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RephraseResponse {
+
+    private String emoji;    // 꿈을 상징하는 이모지
+    private String title;    // 꿈 제목
+    private String content;  // 꿈 원문
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/UnconsciousResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/UnconsciousResponse.java
@@ -1,0 +1,15 @@
+package com.goormthon.univ.simhae.domain.fastapi.dto.overall;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UnconsciousResponse {
+
+    private String categoryName;      // 무의식 카테고리명
+    private String interpretation;    // 꿈 해석 내용
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/unconscious/UnconsciousAnalysisResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/unconscious/UnconsciousAnalysisResponse.java
@@ -1,0 +1,14 @@
+package com.goormthon.univ.simhae.domain.fastapi.dto.unconscious;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UnconsciousAnalysisResponse {
+
+    private String unconsciousMeaning;
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/unconscious/UnconsciousAnalyzeRequest.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/unconscious/UnconsciousAnalyzeRequest.java
@@ -1,0 +1,22 @@
+package com.goormthon.univ.simhae.domain.fastapi.dto.unconscious;
+
+import java.util.List;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 무의식 분석 요청 DTO
+ * - 최근 7개의 꿈 해석 결과를 요청 본문으로 전달
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class UnconsciousAnalyzeRequest {
+
+    @Size(min = 7)
+    private List<String> recentDreamAnalyses; // 항상 7개의 꿈 해석 결과
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/service/DreamAnalysisService.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/service/DreamAnalysisService.java
@@ -1,0 +1,62 @@
+package com.goormthon.univ.simhae.domain.fastapi.service;
+
+import com.goormthon.univ.simhae.domain.dream.entity.Dream;
+import com.goormthon.univ.simhae.domain.dream.repository.DreamRepository;
+import com.goormthon.univ.simhae.domain.fastapi.dto.overall.DreamAnalyzeRequest;
+import com.goormthon.univ.simhae.domain.fastapi.dto.unconscious.UnconsciousAnalysisResponse;
+import com.goormthon.univ.simhae.domain.fastapi.dto.unconscious.UnconsciousAnalyzeRequest;
+import com.goormthon.univ.simhae.global.exception.message.ErrorMessage;
+import com.goormthon.univ.simhae.global.exception.model.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class DreamAnalysisService {
+
+    private final DreamRepository dreamRepository;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${deploy.fastapi_url}")
+    private String FAST_API_URL;
+
+    /**
+     * 전체 분석 호출
+     */
+    public Map<String, Object> analyzeOverall(DreamAnalyzeRequest request) {
+        String url = "http://" + FAST_API_URL + "/ai/dreams/overall";
+        // FastAPI POST 호출
+        return restTemplate.postForObject(url, request, Map.class);
+    }
+
+    /**
+     * 무의식 분석 호출 - 최근 7개 꿈
+     */
+    public UnconsciousAnalysisResponse analyzeUnconscious(Long userId) {
+        List<Dream> recentDreams = dreamRepository.findTop7ByUserIdOrderByCreatedAtDesc(userId);
+
+        // 최소 7개 검사
+        if (recentDreams.size() < 7) {
+            throw new BadRequestException(ErrorMessage.UNCONSCIOUS_MIN_DREAMS);
+        }
+
+        UnconsciousAnalyzeRequest request = new UnconsciousAnalyzeRequest(
+                recentDreams.stream()
+                        .map(Dream::getInterpretation)
+                        .collect(Collectors.toList())
+        );
+
+        String url = "http://" + FAST_API_URL + "/ai/dreams/unconscious";
+        return restTemplate.postForObject(url, request, UnconsciousAnalysisResponse.class);
+    }
+
+}

--- a/src/main/java/com/goormthon/univ/simhae/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/exception/GlobalExceptionHandler.java
@@ -36,12 +36,16 @@ public class GlobalExceptionHandler {
                 case "NotNull", "NotBlank" -> errorMessage = ErrorMessage.REQUIRED_FIELD_MISSING;
                 case "Size" -> {
                     int min = (int) fieldError.getArguments()[1];
-                    int max = (int) fieldError.getArguments()[2];
+                    int max = (int) fieldError.getArguments()[2]; // max는 필요 없음
 
                     if (length < min) {
-                        errorMessage = ErrorMessage.INPUT_VALUE_TOO_SHORT; // 최소 길이 미만
+                        if ("recentDreamAnalyses".equals(fieldError.getField())) {
+                            errorMessage = ErrorMessage.UNCONSCIOUS_MIN_DREAMS;
+                        } else {
+                            errorMessage = ErrorMessage.INPUT_VALUE_TOO_SHORT;
+                        }
                     } else if (length > max) {
-                        errorMessage = ErrorMessage.INPUT_VALUE_TOO_LONG;  // 최대 길이 초과
+                        errorMessage = ErrorMessage.INPUT_VALUE_TOO_LONG;
                     }
                 }
             }

--- a/src/main/java/com/goormthon/univ/simhae/global/exception/message/ErrorMessage.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/exception/message/ErrorMessage.java
@@ -14,6 +14,7 @@ public enum ErrorMessage {
 
     // 404 Not Found
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 데이터를 찾을 수 없습니다"),
+    UNCONSCIOUS_MIN_DREAMS(HttpStatus.BAD_REQUEST.value(), "무의식 분석을 위해 최소 7개의 꿈 해석이 필요합니다"),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다"),

--- a/src/main/java/com/goormthon/univ/simhae/global/exception/message/SuccessMessage.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/exception/message/SuccessMessage.java
@@ -16,6 +16,7 @@ public enum SuccessMessage {
     201 Created
      */
     CREATE_SUCCESS(HttpStatus.CREATED.value(), "꿈 해몽 생성이 완료되었습니다"),
+    UNCONSCIOUS_SUCCESS(HttpStatus.CREATED.value(), "무의식 분석이 완료되었습니다"),
 
     /*
     204 No Content

--- a/src/test/java/com/goormthon/univ/simhae/domain/fastapi/controller/DreamAnalysisControllerTest.java
+++ b/src/test/java/com/goormthon/univ/simhae/domain/fastapi/controller/DreamAnalysisControllerTest.java
@@ -1,0 +1,126 @@
+package com.goormthon.univ.simhae.domain.fastapi.controller;
+
+import com.goormthon.univ.simhae.domain.dream.entity.Dream;
+import com.goormthon.univ.simhae.domain.fastapi.dto.overall.RephraseResponse;
+import com.goormthon.univ.simhae.domain.fastapi.dto.overall.UnconsciousResponse;
+import com.goormthon.univ.simhae.domain.fastapi.dto.overall.RecommendationResponse;
+import com.goormthon.univ.simhae.domain.fastapi.dto.unconscious.UnconsciousAnalysisResponse;
+import com.goormthon.univ.simhae.domain.fastapi.service.DreamAnalysisService;
+import com.goormthon.univ.simhae.global.exception.GlobalExceptionHandler;
+import com.goormthon.univ.simhae.global.exception.message.ErrorMessage;
+import com.goormthon.univ.simhae.global.exception.model.BadRequestException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class DreamAnalysisControllerTest {
+
+    @Mock
+    private DreamAnalysisService dreamAnalysisService;
+
+    @InjectMocks
+    private DreamAnalysisController dreamAnalysisController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        // GlobalExceptionHandler 등록
+        mockMvc = MockMvcBuilders.standaloneSetup(dreamAnalysisController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+
+    @Test
+    void 꿈_해몽_생성_성공() throws Exception {
+        Map<String, Object> dummy = new HashMap<>();
+        dummy.put("rephrase", new RephraseResponse("💭", "하늘을 나는 꿈", "하늘을 자유롭게 날았다"));
+        dummy.put("unconscious", new UnconsciousResponse("기쁨", "자유와 성취감을 느끼고 있음"));
+        dummy.put("recommendation", new RecommendationResponse("최근 스트레스 요인을 줄이고, 긍정적인 활동 계획을 세워보세요."));
+
+        Mockito.when(dreamAnalysisService.analyzeOverall(any()))
+                .thenReturn(dummy);
+
+        mockMvc.perform(post("/ai/dreams/overall")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"하늘을 나는 꿈\", \"dreamDate\":\"2025-08-29\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.message").value("꿈 해몽 생성이 완료되었습니다"))
+                .andExpect(jsonPath("$.data.rephrase.emoji").value("💭"))
+                .andExpect(jsonPath("$.data.rephrase.title").value("하늘을 나는 꿈"))
+                .andExpect(jsonPath("$.data.rephrase.content").value("하늘을 자유롭게 날았다"));
+    }
+
+    @Test
+    void 무의식_분석_생성_성공() throws Exception {
+        UnconsciousAnalysisResponse dummy = new UnconsciousAnalysisResponse(
+                "최근 반복되는 불안과 긴장 패턴이 꿈에 반영되어 있습니다."
+        );
+
+        Mockito.when(dreamAnalysisService.analyzeUnconscious(anyLong()))
+                .thenReturn(dummy);
+
+        mockMvc.perform(post("/ai/dreams/unconscious")
+                        .param("userId", "1"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.message").value("무의식 분석이 완료되었습니다"))
+                .andExpect(jsonPath("$.data.unconsciousMeaning")
+                        .value("최근 반복되는 불안과 긴장 패턴이 꿈에 반영되어 있습니다."));
+    }
+
+    @Test
+    void 무의식_분석_예외_및_성공_테스트() throws Exception {
+        // 최근 꿈 7개 정상 데이터
+        List<Object> recent7Dreams = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            recent7Dreams.add(new Object());
+        }
+
+        Mockito.when(dreamAnalysisService.analyzeUnconscious(anyLong()))
+                .thenAnswer(invocation -> {
+                    if (recent7Dreams.size() < 7) {
+                        throw new BadRequestException(ErrorMessage.UNCONSCIOUS_MIN_DREAMS);
+                    }
+                    return new UnconsciousAnalysisResponse("최근 반복되는 불안과 긴장 패턴이 꿈에 반영되어 있습니다.");
+                });
+
+        // 정상 7개일 때
+        mockMvc.perform(post("/ai/dreams/unconscious")
+                        .param("userId", "1"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.message").value("무의식 분석이 완료되었습니다"))
+                .andExpect(jsonPath("$.data.unconsciousMeaning")
+                        .value("최근 반복되는 불안과 긴장 패턴이 꿈에 반영되어 있습니다."));
+
+        // 6개만 남겼을 때 (테스트 시 수동으로 recent7Dreams.remove(0) 등)
+        recent7Dreams.remove(0); // 이제 6개
+        mockMvc.perform(post("/ai/dreams/unconscious")
+                        .param("userId", "1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message")
+                        .value("무의식 분석을 위해 최소 7개의 꿈 해석이 필요합니다"));
+    }
+
+}


### PR DESCRIPTION
## Related Issues
- #6 

## 작업 내용
- 꿈 해몽 서비스 및 Repository 구현
- 전체 분석, 무의식 분석에 대한 DTO 구현
- 전체 분석 (/overall), 무의식 분석 (/unconscious) 컨트롤러 구현
- 글로벌 예외 처리 및 성공/에러 메시지 수정

## 참고 사항
- 서비스 계층에서 RestTemplate으로 AI 분석 호출
- 테스트 코드 작성: 꿈 해몽 생성 성공, 무의식 분석 성공/예외 처리

## ScreenShot
<img width="488" height="200" alt="image" src="https://github.com/user-attachments/assets/f899daac-59d8-4611-ab61-252cfe496bda" />

