### PR TITLE
FastAPI 연동 및 AI 꿈 분석 안정화

### DIFF
--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/repository/DreamRepository.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/repository/DreamRepository.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface DreamRepository extends JpaRepository<Dream, Long> {
 
-    List<Dream> findTop7ByUserIdOrderByCreatedAtDesc(Long userId);
+    List<Dream> findTop7ByUserIdOrderByCreatedDateDesc(Long userId);
 
 }

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/RephraseResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/RephraseResponse.java
@@ -11,6 +11,6 @@ public class RephraseResponse {
 
     private String emoji;    // 꿈을 상징하는 이모지
     private String title;    // 꿈 제목
-    private String content;  // 꿈 원문
+    private String content;  // 꿈 내용
 
 }

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/unconscious/UnconsciousAnalysisResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/unconscious/UnconsciousAnalysisResponse.java
@@ -1,14 +1,14 @@
 package com.goormthon.univ.simhae.domain.fastapi.dto.unconscious;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class UnconsciousAnalysisResponse {
 
-    private String unconsciousMeaning;
+    private String analysis;
 
 }

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/service/DreamAnalysisService.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/service/DreamAnalysisService.java
@@ -1,5 +1,8 @@
 package com.goormthon.univ.simhae.domain.fastapi.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.goormthon.univ.simhae.domain.dream.entity.Dream;
 import com.goormthon.univ.simhae.domain.dream.repository.DreamRepository;
 import com.goormthon.univ.simhae.domain.fastapi.dto.overall.DreamAnalyzeRequest;
@@ -9,6 +12,7 @@ import com.goormthon.univ.simhae.global.exception.message.ErrorMessage;
 import com.goormthon.univ.simhae.global.exception.model.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
@@ -19,15 +23,30 @@ import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
-@RequiredArgsConstructor
 public class DreamAnalysisService {
 
     private final DreamRepository dreamRepository;
-
-    private final RestTemplate restTemplate = new RestTemplate();
+    private final RestTemplate restTemplate;
 
     @Value("${deploy.fastapi_url}")
     private String FAST_API_URL;
+
+    public DreamAnalysisService(DreamRepository dreamRepository) {
+        this.dreamRepository = dreamRepository;
+
+        // ObjectMapper 커스터마이징
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule()); // LocalDate 지원
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setObjectMapper(mapper);
+
+        this.restTemplate = new RestTemplate();
+        // 기존 converter 제거 후 새 converter 추가
+        this.restTemplate.getMessageConverters().removeIf(c -> c instanceof MappingJackson2HttpMessageConverter);
+        this.restTemplate.getMessageConverters().add(converter);
+    }
 
     /**
      * 전체 분석 호출
@@ -42,13 +61,13 @@ public class DreamAnalysisService {
      * 무의식 분석 호출 - 최근 7개 꿈
      */
     public UnconsciousAnalysisResponse analyzeUnconscious(Long userId) {
-        List<Dream> recentDreams = dreamRepository.findTop7ByUserIdOrderByCreatedAtDesc(userId);
+        List<Dream> recentDreams = dreamRepository.findTop7ByUserIdOrderByCreatedDateDesc(userId);
 
         // 최소 7개 검사
         if (recentDreams.size() < 7) {
             throw new BadRequestException(ErrorMessage.UNCONSCIOUS_MIN_DREAMS);
         }
-
+        //
         UnconsciousAnalyzeRequest request = new UnconsciousAnalyzeRequest(
                 recentDreams.stream()
                         .map(Dream::getInterpretation)


### PR DESCRIPTION
## Related Issues
- #8 

## 작업 내용
최근 7개 꿈 조회 기준 createdAt → dreamDate로 수정
FastAPI 호출 및 DTO 연동 로직 수정, 리스트 → 단일 분석 결과 처리
전체적으로 Spring ↔ FastAPI 연동 안정화 및 OpenAI 호출 정상 동작 확인

## 참고 사항
FastAPI 반환 JSON 구조 변경 반영 및 DTO 동기화 완료

## ScreenShot
<img width="700" height="1223" alt="스크린샷 2025-08-31 오후 7 09 11" src="https://github.com/user-attachments/assets/ecd42945-724f-45c3-9457-52b969e855d9" />
