### PR TITLE
꿈 목록(월별), 일별 조회 및 상세 조회 구현

### DIFF
--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/controller/DreamController.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/controller/DreamController.java
@@ -1,0 +1,100 @@
+package com.goormthon.univ.simhae.domain.dream.controller;
+
+import com.goormthon.univ.simhae.domain.dream.dto.DreamResponse;
+import com.goormthon.univ.simhae.domain.dream.service.DreamService;
+import com.goormthon.univ.simhae.global.dto.ErrorResponse;
+import com.goormthon.univ.simhae.global.dto.SuccessResponse;
+import com.goormthon.univ.simhae.global.exception.message.ErrorMessage;
+import com.goormthon.univ.simhae.global.exception.message.SuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/dreams")
+@RequiredArgsConstructor
+public class DreamController {
+
+    private final DreamService dreamService;
+
+    /**
+     * 월별 조회 + 검색 통합
+     * GET /dreams?dreamDate=yyyy-MM&keyword=...  (모두 옵션)
+     * - dreamDate 미지정 시 현재 월로 기본값 처리
+     * - keyword 있으면 2~20자 검증 + title/summary/content에서 검색
+     */
+    @GetMapping
+    public ResponseEntity<?> getDreamsByMonth(
+            @RequestParam(value = "dreamDate", required = false) String month, // yyyy-MM
+            @RequestParam(value = "keyword",   required = false) String keyword
+    ) {
+        // keyword 길이 검증
+        if (keyword != null && !keyword.isBlank()) {
+            String k = keyword.trim();
+            if (k.length() < 2)  return ResponseEntity.badRequest()
+                    .body(ErrorResponse.of(ErrorMessage.INPUT_VALUE_TOO_SHORT));
+            if (k.length() > 20) return ResponseEntity.badRequest()
+                    .body(ErrorResponse.of(ErrorMessage.INPUT_VALUE_TOO_LONG));
+            keyword = k;
+        }
+
+        // month 파싱(옵션 → 기본값 현재월)
+        final YearMonth ym;
+        if (month == null || month.isBlank()) {
+            ym = YearMonth.now();
+        } else {
+            try {
+                ym = YearMonth.parse(month); // yyyy-MM
+            } catch (DateTimeParseException e) {
+                return ResponseEntity.badRequest()
+                        .body(ErrorResponse.of(400, "dreamDate는 yyyy-MM 형식이어야 합니다. 예) 2025-08"));
+            }
+        }
+
+        List<DreamResponse> data = dreamService.getDreamsByMonth(ym, keyword);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, data));
+    }
+
+    /**
+     * 일별 조회 (dreamDate만)
+     * GET /dreams/day?dreamDate=yyyy-MM-dd
+     */
+    @GetMapping("/day")
+    public ResponseEntity<?> getDreamsByDay(
+            @RequestParam("dreamDate") String date // yyyy-MM-dd (필수)
+    ) {
+        if (date == null || date.isBlank()) {
+            return ResponseEntity.badRequest()
+                    .body(ErrorResponse.of(ErrorMessage.REQUIRED_FIELD_MISSING));
+        }
+        final LocalDate day;
+        try {
+            day = LocalDate.parse(date);
+        } catch (DateTimeParseException e) {
+            return ResponseEntity.badRequest()
+                    .body(ErrorResponse.of(400, "dreamDate는 yyyy-MM-dd 형식이어야 합니다. 예) 2025-08-22"));
+        }
+
+        List<DreamResponse> data = dreamService.getDreamsByDay(day);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, data));
+    }
+
+    /**
+     * 상세 조회
+     * GET /dreams/{dreamId}
+     */
+    @GetMapping("/{dreamId}")
+    public ResponseEntity<?> getDreamDetail(@PathVariable Long dreamId) {
+        return dreamService.getDreamDetail(dreamId)
+                .<ResponseEntity<?>>map(detail ->
+                        ResponseEntity.ok(SuccessResponse.of(SuccessMessage.LOAD_SUCCESS, detail)))
+                .orElseGet(() ->
+                        ResponseEntity.status(404).body(ErrorResponse.of(ErrorMessage.RESOURCE_NOT_FOUND)));
+    }
+}
+

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/dto/DreamDetailResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/dto/DreamDetailResponse.java
@@ -1,0 +1,17 @@
+package com.goormthon.univ.simhae.domain.dream.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record DreamDetailResponse(
+        Long dreamId,
+        LocalDate dreamDate,
+        LocalDateTime createdAt,
+        String title,
+        String emoji,
+        String category,
+        String summary,
+        String interpretation,
+        String suggestion
+) {
+}

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/dto/DreamResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/dto/DreamResponse.java
@@ -1,0 +1,16 @@
+package com.goormthon.univ.simhae.domain.dream.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record DreamResponse(
+        Long dreamId,
+        LocalDate dreamDate,
+        String title,
+        String emoji,
+        String summary,
+        String content,
+        String category,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/repository/DreamRepository.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/repository/DreamRepository.java
@@ -2,11 +2,38 @@ package com.goormthon.univ.simhae.domain.dream.repository;
 
 import com.goormthon.univ.simhae.domain.dream.entity.Dream;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface DreamRepository extends JpaRepository<Dream, Long> {
 
     List<Dream> findTop7ByUserIdOrderByCreatedDateDesc(Long userId);
+
+    // 월별 + 키워드(옵션)
+    @Query("""
+        SELECT d
+        FROM Dream d
+        WHERE d.dreamDate >= :startDate
+          AND d.dreamDate <  :endDate
+          AND (
+              :keyword IS NULL OR :keyword = '' OR
+              LOWER(d.title)   LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+              LOWER(d.summary) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+              LOWER(d.content) LIKE LOWER(CONCAT('%', :keyword, '%'))
+          )
+        ORDER BY d.dreamDate DESC, d.id DESC
+        """)
+    List<Dream> findByMonthAndKeyword(
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate")   LocalDate endDate,
+            @Param("keyword")   String keyword
+    );
+
+    // 일별
+    List<Dream> findByDreamDate(LocalDate dreamDate);
 
 }

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/service/DreamService.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/service/DreamService.java
@@ -1,0 +1,80 @@
+package com.goormthon.univ.simhae.domain.dream.service;
+
+
+import com.goormthon.univ.simhae.domain.dream.dto.DreamDetailResponse;
+import com.goormthon.univ.simhae.domain.dream.dto.DreamResponse;
+import com.goormthon.univ.simhae.domain.dream.entity.Dream;
+import com.goormthon.univ.simhae.domain.dream.entity.value.Category;
+import com.goormthon.univ.simhae.domain.dream.repository.DreamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DreamService {
+
+    private final DreamRepository dreamRepository;
+
+    public List<DreamResponse> getDreamsByMonth(YearMonth ym, String keyword) {
+        LocalDate start = ym.atDay(1);
+        LocalDate end   = ym.plusMonths(1).atDay(1);
+
+        return dreamRepository.findByMonthAndKeyword(start, end, keyword)
+                .stream()
+                .map(this::toListDto)
+                .toList();
+    }
+
+    public List<DreamResponse> getDreamsByDay(LocalDate date) {
+        return dreamRepository.findByDreamDate(date)
+                .stream()
+                .map(this::toListDto)
+                .toList();
+    }
+
+    public Optional<DreamDetailResponse> getDreamDetail(Long dreamId) {
+        return dreamRepository.findById(dreamId)
+                .map(d -> new DreamDetailResponse(
+                        d.getId(),
+                        d.getDreamDate(),
+                        d.getCreatedDate(),
+                        d.getTitle(),
+                        d.getEmoji(),
+                        toKorean(d.getCategory()),
+                        d.getSummary(),
+                        d.getInterpretation(),
+                        d.getSuggestion()
+                ));
+    }
+
+    private DreamResponse toListDto(Dream d) {
+        return new DreamResponse(
+                d.getId(),
+                d.getDreamDate(),
+                d.getTitle(),
+                d.getEmoji(),
+                d.getSummary(),
+                d.getContent(),
+                toKorean(d.getCategory()),
+                d.getCreatedDate()
+        );
+    }
+
+    private String toKorean(Category c) {
+        if (c == null) return null;
+        return switch (c) {
+            case ANXIETY -> "불안";
+            case JOY     -> "기쁨";
+            case SADNESS -> "슬픔";
+            case ANGER   -> "분노";
+            case OTHER   -> "기타";
+        };
+    }
+}


### PR DESCRIPTION
## Related Issues
- #5 
## 작업 내용
- DreamResponse, DreamDetailResponse DTO 생성
- 꿈 목록(월별) 조회 및 키워드 검색 API 구현
- 일별 조회 API 구현
- 상세 조회 API 구현

## 참고 사항
<!-- 리뷰 참고사항 필요 시 작성 -->

## ScreenShot
<!-- 필요하다면 캡처 이미지 첨부 -->