### PR TITLE
꿈 카테고리 반영 및 응답 처리

### DIFF
--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/dto/DreamDetailResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/dto/DreamDetailResponse.java
@@ -10,7 +10,6 @@ public record DreamDetailResponse(
         String title,
         String emoji,
         String category,
-        String summary,
         String interpretation,
         String suggestion
 ) {

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/dto/DreamResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/dto/DreamResponse.java
@@ -8,7 +8,6 @@ public record DreamResponse(
         LocalDate dreamDate,
         String title,
         String emoji,
-        String summary,
         String content,
         String category,
         LocalDateTime createdAt

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/entity/Dream.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/entity/Dream.java
@@ -35,9 +35,6 @@ public class Dream extends BaseEntity {
 
     private String emoji;
 
-    @Column(columnDefinition = "TEXT")
-    private String summary;
-
     @Column(columnDefinition = "TEXT", nullable = false)
     @NotNull
     private String content;

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/entity/value/Category.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/entity/value/Category.java
@@ -1,9 +1,23 @@
 package com.goormthon.univ.simhae.domain.dream.entity.value;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum Category {
-    ANXIETY, // 불안
-    JOY,     // 기쁨
-    SADNESS, // 슬픔
-    ANGER,   // 분노
-    OTHER    // 기타
+
+    DAILY_REFLECTION("일상 반영 꿈", "낮 동안의 경험이나 생각이 꿈속에 그대로 혹은 부분적으로 재현된 꿈"),
+    WISH_FULFILLMENT("소망 충족 꿈", "현실에서 충족하지 못한 욕망이나 억압된 소망을 꿈속에서 달성하는 꿈"),
+    NIGHTMARE("악몽 / 불안 꿈", "공포, 불안, 위협을 강하게 경험하게 되는 꿈"),
+    RECURRING("반복 꿈", "동일하거나 유사한 내용이 여러 차례 반복되는 꿈"),
+    SYMBOLIC("상징적 꿈", "직접적 사건이 아니라 상징적 이미지로 무의식을 드러내는 꿈"),
+    PRECOGNITIVE("예지 / 직관 꿈", "미래 사건을 암시하거나 예감하는 꿈"),
+    CREATIVE("창의적 / 문제 해결 꿈", "창작 활동이나 문제 해결 아이디어를 제공하는 꿈"),
+    SOMATIC("신체 반영 꿈", "실제 신체 상태나 자극이 꿈에 반영되는 꿈"),
+    LUCID("자각몽", "꿈꾸는 중에 자신이 꿈꾸고 있음을 자각하는 꿈"),
+    SURREAL("초현실 / 비논리적 꿈", "현실의 법칙을 벗어난 기이하고 비논리적인 꿈");
+
+    private final String name;        // 한글 이름
+    private final String description; // 정의
 }

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/repository/DreamRepository.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/repository/DreamRepository.java
@@ -22,7 +22,6 @@ public interface DreamRepository extends JpaRepository<Dream, Long> {
           AND (
               :keyword IS NULL OR :keyword = '' OR
               LOWER(d.title)   LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-              LOWER(d.summary) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
               LOWER(d.content) LIKE LOWER(CONCAT('%', :keyword, '%'))
           )
         ORDER BY d.dreamDate DESC, d.id DESC

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/service/DreamService.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/service/DreamService.java
@@ -48,7 +48,6 @@ public class DreamService {
                         d.getTitle(),
                         d.getEmoji(),
                         toKorean(d.getCategory()),
-                        d.getSummary(),
                         d.getInterpretation(),
                         d.getSuggestion()
                 ));
@@ -60,7 +59,6 @@ public class DreamService {
                 d.getDreamDate(),
                 d.getTitle(),
                 d.getEmoji(),
-                d.getSummary(),
                 d.getContent(),
                 toKorean(d.getCategory()),
                 d.getCreatedDate()
@@ -70,11 +68,17 @@ public class DreamService {
     private String toKorean(Category c) {
         if (c == null) return null;
         return switch (c) {
-            case ANXIETY -> "불안";
-            case JOY     -> "기쁨";
-            case SADNESS -> "슬픔";
-            case ANGER   -> "분노";
-            case OTHER   -> "기타";
+            case DAILY_REFLECTION -> "일상 반영 꿈";
+            case WISH_FULFILLMENT -> "소망 충족 꿈";
+            case NIGHTMARE        -> "악몽 / 불안 꿈";
+            case RECURRING       -> "반복 꿈";
+            case SYMBOLIC         -> "상징적 꿈";
+            case PRECOGNITIVE     -> "예지 / 직관 꿈";
+            case CREATIVE         -> "창의적 / 문제 해결 꿈";
+            case SOMATIC         -> "신체 반영 꿈";
+            case LUCID            -> "자각몽";
+            case SURREAL          -> "초현실 / 비논리적 꿈";
         };
     }
+
 }

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/RephraseResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/dto/overall/RephraseResponse.java
@@ -12,5 +12,7 @@ public class RephraseResponse {
     private String emoji;    // 꿈을 상징하는 이모지
     private String title;    // 꿈 제목
     private String content;  // 꿈 내용
+    private String categoryName;         // 꿈 카테고리
+    private String categoryDescription;  // 정의
 
 }

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/service/DreamAnalysisService.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/service/DreamAnalysisService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.goormthon.univ.simhae.domain.dream.entity.Dream;
+import com.goormthon.univ.simhae.domain.dream.entity.value.Category;
 import com.goormthon.univ.simhae.domain.dream.repository.DreamRepository;
 import com.goormthon.univ.simhae.domain.fastapi.dto.overall.DreamAnalyzeRequest;
 import com.goormthon.univ.simhae.domain.fastapi.dto.unconscious.UnconsciousAnalysisResponse;
@@ -67,10 +68,14 @@ public class DreamAnalysisService {
         String url = "http://" + FAST_API_URL + "/ai/dreams/overall";
         Map<String, Object> response = restTemplate.postForObject(url, request, Map.class);
 
-        // FastAPI 응답에서 바로 Map 가져오기
+        // FastAPI 응답에서 Map 가져오기
         Map<String, Object> restate = (Map<String, Object>) response.get("restate");
         Map<String, Object> unconscious = (Map<String, Object>) response.get("unconscious");
         Map<String, Object> suggestionMap = (Map<String, Object>) response.get("suggestion");
+
+        // category 문자열을 Enum으로 변환
+        String categoryStr = (String) restate.get("category");
+        Category categoryEnum = Category.valueOf(categoryStr);
 
         // Dream 엔티티 생성 및 저장
         Dream dream = Dream.builder()
@@ -78,14 +83,14 @@ public class DreamAnalysisService {
                 .title((String) restate.get("title"))
                 .emoji((String) restate.get("emoji"))
                 .content((String) restate.get("content"))
-                .summary((String) restate.getOrDefault("summary", restate.get("content")))
+                .category(categoryEnum)
                 .interpretation((String) unconscious.get("analysis"))
                 .suggestion((String) suggestionMap.get("suggestion"))
                 .dreamDate(LocalDate.now())
-                .category(null)
                 .build();
 
         dreamRepository.save(dream);
+
         return response;
     }
 

--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/service/DreamAnalysisService.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/service/DreamAnalysisService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -60,7 +61,7 @@ public class DreamAnalysisService {
      */
     @Transactional
     public Map<String, Object> analyzeOverall(DreamAnalyzeRequest request, String externalId) {
-        // externalId로 User 조회
+        // User 조회
         User user = userRepository.findByExternalId(externalId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.USER_NOT_FOUND));
 
@@ -68,12 +69,11 @@ public class DreamAnalysisService {
         String url = "http://" + FAST_API_URL + "/ai/dreams/overall";
         Map<String, Object> response = restTemplate.postForObject(url, request, Map.class);
 
-        // FastAPI 응답에서 Map 가져오기
         Map<String, Object> restate = (Map<String, Object>) response.get("restate");
         Map<String, Object> unconscious = (Map<String, Object>) response.get("unconscious");
         Map<String, Object> suggestionMap = (Map<String, Object>) response.get("suggestion");
 
-        // category 문자열을 Enum으로 변환
+        // Category 문자열을 ENUM으로 변환
         String categoryStr = (String) restate.get("category");
         Category categoryEnum = Category.valueOf(categoryStr);
 
@@ -91,7 +91,27 @@ public class DreamAnalysisService {
 
         dreamRepository.save(dream);
 
-        return response;
+        // 클라이언트 응답용 Map 구성
+        Map<String, Object> clientResponse = new HashMap<>();
+        Map<String, Object> restateMap = new HashMap<>();
+        restateMap.put("emoji", dream.getEmoji());
+        restateMap.put("title", dream.getTitle());
+        restateMap.put("content", dream.getContent());
+        restateMap.put("categoryName", categoryEnum.getName());
+        restateMap.put("categoryDescription", categoryEnum.getDescription());
+
+        Map<String, Object> unconsciousMap = new HashMap<>();
+        unconsciousMap.put("analysis", dream.getInterpretation());
+
+        Map<String, Object> suggestionMapOut = new HashMap<>();
+        suggestionMapOut.put("suggestion", dream.getSuggestion());
+
+        clientResponse.put("restate", restateMap);
+        clientResponse.put("unconscious", unconsciousMap);
+        clientResponse.put("suggestion", suggestionMapOut);
+
+        // 이렇게 바로 반환
+        return clientResponse;
     }
 
     /**


### PR DESCRIPTION
## Related Issues
- #20 

## 작업 내용
- 꿈 DTO 및 RephraseResponse에 category 필드 추가
- DreamService와 DreamAnalysisService에서 GPT 응답 기반 꿈 카테고리 저장 및 반환 로직 구현
- 기존 꿈 해몽 저장 로직 유지하면서 카테고리 Enum 연동

## 참고 사항
- 카테고리 정보는 Enum을 기반으로 내부적으로 관리하며, 프론트에는 category.getName()과 category.getDescription()을 이용해 한글 이름과 정의를 내려줌

## ScreenShot
<img width="651" height="362" alt="2025-09-05_5 05 12" src="https://github.com/user-attachments/assets/3aaa7d90-ed49-4f35-99c6-2cc6b8abac6f" />
