### PR TITLE
꿈 상세 조회 시 content 추가 및 category Enum 매핑

### DIFF
--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/dto/DreamDetailResponse.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/dto/DreamDetailResponse.java
@@ -9,7 +9,9 @@ public record DreamDetailResponse(
         LocalDateTime createdAt,
         String title,
         String emoji,
-        String category,
+        String content,
+        String categoryName,
+        String categoryDescription,
         String interpretation,
         String suggestion
 ) {

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/service/DreamService.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/service/DreamService.java
@@ -47,7 +47,9 @@ public class DreamService {
                         d.getCreatedDate(),
                         d.getTitle(),
                         d.getEmoji(),
-                        toKorean(d.getCategory()),
+                        d.getContent(), // content 추가
+                        d.getCategory().getName(),          // categoryName
+                        d.getCategory().getDescription(),   // categoryDescription
                         d.getInterpretation(),
                         d.getSuggestion()
                 ));


### PR DESCRIPTION
## Related Issues
- #23 

## 작업 내용
- 꿈 상세 조회 시 content 필드 추가
- category를 Enum으로 매핑하여 categoryName과 categoryDescription 제공

## 참고 사항

## ScreenShot
- "content": "꿈에서 철판 아이스크림을 만드는 과정에서 즐거움과 동시에 압박감을 느꼈습니다.",
- "categoryName": "일상 반영 꿈",
- "categoryDescription": "낮 동안의 경험이나 생각이 꿈속에 그대로 혹은 부분적으로 재현된 꿈",