### PR TITLE
꿈 저장 시 요청한 날짜와 다른 날짜로 저장되는 문제

### DIFF
--- a/src/main/java/com/goormthon/univ/simhae/domain/fastapi/service/DreamAnalysisService.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/fastapi/service/DreamAnalysisService.java
@@ -86,7 +86,7 @@ public class DreamAnalysisService {
                 .category(categoryEnum)
                 .interpretation((String) unconscious.get("analysis"))
                 .suggestion((String) suggestionMap.get("suggestion"))
-                .dreamDate(LocalDate.now())
+                .dreamDate(request.getDreamDate())
                 .build();
 
         dreamRepository.save(dream);


### PR DESCRIPTION
## Related Issues
- #28 

## 작업 내용
- 꿈 저장 시 dreamDate가 항상 LocalDate.now()로 저장되던 문제 수정
- 프론트엔드에서 전달한 dreamDate 값을 그대로 저장하도록 로직 변경
- 클라이언트 응답 시에도 올바른 날짜가 반환되도록 개선

## 참고 사항
FastAPI 응답에는 날짜 정보가 없으므로, 요청 DTO에서 전달받은 dreamDate를 저장하는 방식으로 처리

## ScreenShot
<!-- 필요하다면 캡처 이미지 첨부 -->