### PR TITLE
꿈 삭제 API 기능 구현

### DIFF
--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/controller/DreamController.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/controller/DreamController.java
@@ -128,5 +128,33 @@ public class DreamController {
                 .orElseGet(() ->
                         ResponseEntity.status(404).body(ErrorResponse.of(ErrorMessage.RESOURCE_NOT_FOUND)));
     }
+
+    @DeleteMapping("/{dreamId}")
+    public ResponseEntity<?> deleteDream(
+            @RequestHeader(name = HEADER_ANON, required = false) String externalId,
+            @PathVariable Long dreamId
+    ){
+        // 헤더 검증
+        if (externalId == null || externalId.isBlank()) {
+            return ResponseEntity.badRequest()
+                    .body(ErrorResponse.of(ErrorMessage.REQUIRED_FIELD_MISSING));
+        }
+        // 사용자 확인
+        Long userId = userService.getUserIdOrNullByExternalId(externalId.trim());
+        if (userId == null) {
+            return ResponseEntity.status(404)
+                    .body(ErrorResponse.of(ErrorMessage.RESOURCE_NOT_FOUND));
+        }
+
+        // 소유자 일치하는 꿈 삭제
+        boolean deleted = dreamService.deleteDream(userId, dreamId);
+        if (!deleted) {
+            return ResponseEntity.status(404)
+                    .body(ErrorResponse.of(ErrorMessage.RESOURCE_NOT_FOUND));
+        }
+
+        // 204 No Content (바디 없음)
+        return ResponseEntity.ok(SuccessResponse.of(SuccessMessage.DELETED_SUCCESS));
+    }
 }
 

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/repository/DreamRepository.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/repository/DreamRepository.java
@@ -39,4 +39,5 @@ public interface DreamRepository extends JpaRepository<Dream, Long> {
 
     Optional<Dream> findByIdAndUser_Id(Long id, Long userId);
 
+    long deleteByIdAndUser_Id(Long id, Long userId);
 }

--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/service/DreamService.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/service/DreamService.java
@@ -55,6 +55,11 @@ public class DreamService {
                 ));
     }
 
+    @Transactional
+    public boolean deleteDream(Long userId, Long dreamId) {
+        return dreamRepository.deleteByIdAndUser_Id(dreamId, userId) > 0;
+    }
+
     private DreamResponse toListDto(Dream d) {
         return new DreamResponse(
                 d.getId(),
@@ -82,5 +87,7 @@ public class DreamService {
             case SURREAL          -> "초현실 / 비논리적 꿈";
         };
     }
+
+
 
 }


### PR DESCRIPTION
## Related Issues
- #26 

## 작업 내용
- 헤더 X-Anonymous-Id로 사용자 소유 검증 후 DELETE /dreams/{dreamId}로 꿈 삭제, 성공 시 204·없음/타유저 시 404 반환 적용
- DreamRepository - deleteByIdAndUser_Id 추가 → DreamService - deleteDream(@Transactional)에서 >0 판별 → 컨트롤러에 헤더 검증·미등록 404·삭제 결과 204/404 응답 로직 반영.

## 참고 사항
<!-- 리뷰 참고사항 필요 시 작성 -->

## ScreenShot
<!-- 필요하다면 캡처 이미지 첨부 -->
<img width="365" height="394" alt="스크린샷 2025-09-06 오후 7 47 21" src="https://github.com/user-attachments/assets/17e25639-0e09-4524-a5ca-15684fdee263" />
