### PR TITLE
꿈 조회 에러 메시지 표준화

### DIFF
--- a/src/main/java/com/goormthon/univ/simhae/domain/dream/controller/DreamController.java
+++ b/src/main/java/com/goormthon/univ/simhae/domain/dream/controller/DreamController.java
@@ -65,7 +65,7 @@ public class DreamController {
                 ym = YearMonth.parse(month); // yyyy-MM
             } catch (DateTimeParseException e) {
                 return ResponseEntity.badRequest()
-                        .body(ErrorResponse.of(400, "dreamDate는 yyyy-MM 형식이어야 합니다. 예) 2025-08"));
+                        .body(ErrorResponse.of(ErrorMessage.INVALID_MONTH_FORMAT));
             }
         }
 
@@ -96,7 +96,7 @@ public class DreamController {
         try { day = LocalDate.parse(date); }
         catch (DateTimeParseException e) {
             return ResponseEntity.badRequest()
-                    .body(ErrorResponse.of(400, "dreamDate는 yyyy-MM-dd 형식이어야 합니다. 예) 2025-08-22"));
+                    .body(ErrorResponse.of(ErrorMessage.INVALID_DAY_FORMAT));
         }
 
         List<DreamResponse> data = dreamService.getDreamsByDay(userId, day);

--- a/src/main/java/com/goormthon/univ/simhae/global/exception/message/ErrorMessage.java
+++ b/src/main/java/com/goormthon/univ/simhae/global/exception/message/ErrorMessage.java
@@ -11,6 +11,10 @@ public enum ErrorMessage {
     REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST.value(), "필수 입력값이 누락되었습니다"),
     INPUT_VALUE_TOO_SHORT(HttpStatus.BAD_REQUEST.value(), "입력값이 최소 길이보다 짧습니다"),
     INPUT_VALUE_TOO_LONG(HttpStatus.BAD_REQUEST.value(), "입력값이 최대 길이를 초과했습니다"),
+    INVALID_MONTH_FORMAT(HttpStatus.BAD_REQUEST.value(), "dreamDate는 yyyy-MM 형식이어야 합니다. 예) 2025-08"),
+    INVALID_DAY_FORMAT(HttpStatus.BAD_REQUEST.value(), "dreamDate는 yyyy-MM-dd 형식이어야 합니다. 예) 2025-08-22"),
+
+
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 유저를 찾을 수 없습니다"),


### PR DESCRIPTION
## Related Issues
- #32 

## 작업 내용
- 꿈 조회 API의 에러 메시지 체계를 표준화
- ErrorMessage에 INVALID_MONTH_FORMAT, INVALID_DAY_FORMAT 추가 
- 컨트롤러에서 날짜 파싱 실패 시 해당 코드로 매핑하도록 수정

## 참고 사항
<!-- 리뷰 참고사항 필요 시 작성 -->

## ScreenShot
<!-- 필요하다면 캡처 이미지 첨부 -->