### PR TITLE
ECS 컨테이너 분리 Spring Boot / Nginx

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,9 +21,13 @@ jobs:
       - name: Cache Gradle
         uses: gradle/gradle-build-action@v3
 
-      - name: Build & Test
+      - name: Build & Test (Gradle)
         run: ./gradlew clean build -x test
 
-      - name: Dockerfile Lint & Build Check
+      - name: Dockerfile Lint & Build Check (Spring Boot)
         run: |
-          docker build --no-cache --pull -t simhae-test-image -f Dockerfile .
+          docker build --no-cache --pull -t simhae-springboot-test -f Dockerfile .
+
+      - name: Dockerfile Lint & Build Check (Nginx)
+        run: |
+          docker build --no-cache --pull -t simhae-nginx-test -f nginx/Dockerfile ./nginx

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -35,7 +35,16 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build and push Docker image to ECR
+      - name: Build and push Spring Boot Docker image
         run: |
-          docker buildx build --platform linux/amd64 -t ${{ secrets.ECR_REGISTRY }}/${{ secrets.IMAGE_NAME }}:latest .
-          docker push ${{ secrets.ECR_REGISTRY }}/${{ secrets.IMAGE_NAME }}:latest
+          docker buildx build --platform linux/amd64 \
+            -t ${{ secrets.ECR_REGISTRY }}/${{ secrets.SPRING_IMAGE_NAME }}:latest \
+            -f Dockerfile .
+          docker push ${{ secrets.ECR_REGISTRY }}/${{ secrets.SPRING_IMAGE_NAME }}:latest
+
+      - name: Build and push Nginx Docker image
+        run: |
+          docker buildx build --platform linux/amd64 \
+            -t ${{ secrets.ECR_REGISTRY }}/${{ secrets.NGINX_IMAGE_NAME }}:latest \
+            -f nginx/Dockerfile ./nginx
+          docker push ${{ secrets.ECR_REGISTRY }}/${{ secrets.NGINX_IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,9 @@
 FROM eclipse-temurin:17-jdk
 WORKDIR /app
 
-# Spring Boot jar 복사
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} /app.jar
 
-# Nginx 설치
-RUN apt-get update && apt-get install -y nginx supervisor && \
-    rm -rf /var/lib/apt/lists/*
+EXPOSE 8080
 
-# 설정 파일 복사
-COPY nginx.conf /etc/nginx/nginx.conf
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-
-EXPOSE 80 8080
-
-# supervisord -> Spring Boot + Nginx 실행
-CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,18 @@
+events {}
+
+http {
+    upstream backend {
+        server simhae-ecs-springboot:8080;
+    }
+
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://backend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}


### PR DESCRIPTION
## Related Issues
- close #40 

## 작업 내용
- GitHub Actions 워크플로우 수정
- Spring Boot와 Nginx 컨테이너 분리를 위해 Nginx 전용 Dockerfile/설정 추가 (nginx/)

## 참고 사항
- Nginx 컨테이너는 별도 폴더(nginx/)에 Dockerfile 및 nginx.conf 추가
- ECS 배포 시 Spring Boot + Nginx 컨테이너 연동

## ScreenShot
<!-- 추후 필요 시 캡처 추가 -->